### PR TITLE
Handling `string` as valid, supported `QuestionnaireItemType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following Questionnaire elements are currently supported:
 | Element | Mapping to SurveyJS | Notes & Limitations   |
 | ------- | ------------------- | --------------------- |
 | `item.linkID` | `question.name` |     |
-| `item.type`   | `question.type`   | Only items of type `['group', 'choice', 'display', 'boolean', 'decimal']` are currently supported. See `typeMap()`.  |
+| `item.type`   | `question.type`   | Only items of type `['group', 'choice', 'display', 'boolean', 'decimal','string']` are currently supported. See `typeMap()`.  |
 | `item.text`   | `question.title`  |   |
 | `item._text`  | `question.html`   | Any item [rendering-xhtml extensions](https://www.hl7.org/fhir/extension-rendering-xhtml.html) are added to `question.html`.  |
 | `item.answerOption`   | `question.choices`    | `['valueInteger', 'valueDate', 'valueTime', 'valueString', 'valueCoding']` are the currently supported `answerOption` value choices. See `extractAnswers()` and `getAnswerValues()`.   |

--- a/fhirConversionTools.js
+++ b/fhirConversionTools.js
@@ -103,7 +103,7 @@ export function convertItem(item) {
   let visibility = extractVisibility(item);
   if (visibility.conditions) converted.visibleIf = visibility.conditions;
   if (Object.keys(visibility.expressions).length > 0) {
-    // element.calculatedValues contains referenced calculated value expressions, which must be 
+    // element.calculatedValues contains referenced calculated value expressions, which must be
     // bubbled up to the top of the converted JSON
     calculatedValues.push(visibility.expressions);
   }
@@ -146,13 +146,13 @@ export function convertItem(item) {
       // element.converted contains the converted child item
       converted.elements.push(element.converted);
       if (Object.keys(element.calculatedValues).length > 0) {
-        // element.calculatedValues contains referenced calculated value expressions, which must be 
+        // element.calculatedValues contains referenced calculated value expressions, which must be
         // bubbled up to the top of the converted JSON
         calculatedValues.push(element.calculatedValues);
       }
     });
   }
-  // Need to return the converted item and the calculated values separately, since SurveyJS expects 
+  // Need to return the converted item and the calculated values separately, since SurveyJS expects
   // all calculated values to be defined at the top level in the JSON.
   return {
     converted: converted,
@@ -173,6 +173,7 @@ export function typeMap(fhirItemType, fhirItemRepeats = false) {
     case 'display': return 'html';
     case 'boolean': return 'boolean';
     case 'decimal': return 'text';
+    case 'string': return 'text';
     default:
       throw new Error('Unsupported item type.');
   }
@@ -192,7 +193,7 @@ export function extractAnswers(item) {
       let val = getAnswerValue(ans);
       let extRegExp = /^http:\/\/hl7\.org\/fhir\/StructureDefinition\/ordinalValue/;
       let ordValExt = ans.extension ?
-        ans.extension.filter(ext => extRegExp.test(ext.url)) : 
+        ans.extension.filter(ext => extRegExp.test(ext.url)) :
         [{valueDecimal: 0}];
       answers.push({
         value: val,

--- a/test/conversionTests.js
+++ b/test/conversionTests.js
@@ -5,6 +5,7 @@ import questionnaireOneQuestion from './fixtures/questionnaireOneQuestion.json' 
 import questionnaireMulitpleQuestions from './fixtures/questionnaireMultipleQuestions.json' assert { type: 'json' };
 import questionnaireSupportedExpressionLanguage from './fixtures/questionnaireSupportedExpressionLanguage.json' assert { type: 'json' };
 import questionnaireNestedItems from './fixtures/questionnaireNestedItems.json' assert { type: 'json' };
+import questionnaireStringItemType from './fixtures/questionnaireStringItemType.json' assert { type: 'json' };
 
 describe('Basic conversion tests', function() {
   it('should correctly convert a Questionnaire with a single item with answerOption', function(){
@@ -76,12 +77,28 @@ describe('Basic conversion tests', function() {
     expect(simple.pages[2].questions[0].title).to.equal('Here is a display only question');
     expect(simple.pages[2].questions[0].html).to.equal('Here is a display only question');
     expect(simple.pages[2].questions[0].choices).to.not.exist;
-    
+
   });
+
+  it('should correctly convert a Questionnaire with a string questionnaire item type', function() {
+    const questionnaire = convertFromFhir(questionnaireStringItemType);
+
+    expect(questionnaire).to.exist;
+    expect(questionnaire.pages).to.exist;
+    expect(questionnaire.pages).to.have.lengthOf(1);
+
+    expect(questionnaire.pages[0].questions).to.have.lengthOf(1);
+    expect(questionnaire.pages[0].questions[0].name).to.equal('1');
+    expect(questionnaire.pages[0].questions[0].type).to.equal('text');
+    expect(questionnaire.pages[0].questions[0].title).to.equal('Here is a textual question');
+    expect(questionnaire.pages[0].questions[0].html).to.equal('Here is a textual question')
+    expect(questionnaire.pages[0].questions[0].choices).to.not.exist;
+  });
+
 });
 
 describe('More complex conversion tests', function() {
-  
+
   it('should correctly handle nested items', function(){
     let complex = convertFromFhir(questionnaireNestedItems);
     expect(complex).to.exist;
@@ -105,7 +122,7 @@ describe('More complex conversion tests', function() {
     expect(complex.pages[0].questions[0].elements[1].title).to.equal('Here is a display only question');
     expect(complex.pages[0].questions[0].elements[1].html).to.equal('Here is a display only question');
     expect(complex.pages[0].questions[0].elements[1].choices).to.not.exist;
-    
+
   });
 
   it('should extract calculated expressions and place them in calculatedValues', function(){

--- a/test/fixtures/questionnaireStringItemType.json
+++ b/test/fixtures/questionnaireStringItemType.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "5",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\nTest\n</div>"
+  },
+  "url": "http://hl7.org/fhir/Questionnaire/1",
+  "title": "Questionnaire with a string item type",
+  "status": "draft",
+  "subjectType": [
+    "Patient"
+  ],
+  "date": "2020-03",
+  "item": [
+    {
+      "linkId": "1",
+      "text": "Here is a textual question",
+      "type": "string",
+      "_text": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/rendering-xhtml",
+            "valueString": "Here is a textual question"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/questionnaireUnsupportedItemType.json
+++ b/test/fixtures/questionnaireUnsupportedItemType.json
@@ -16,7 +16,7 @@
     {
       "linkId": "1",
       "text": "Here is a multiple choice question",
-      "type": "string"
+      "type": "float"
     }
-  ]       
+  ]
 }


### PR DESCRIPTION
# Handling `string` as valid, supported `QuestionnaireItemType`

## Problem description

`string` is a supported type for `QuestionnaireItemType` but is not supported in this package.

https://build.fhir.org/valueset-item-type.html

I have updated the test case to test a different, unsupported type than string. I have also added a new test for the new type.